### PR TITLE
Issue #9: pin plotly until they sort out their rc issues

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ Flask-APScheduler>=1.7.0
 passlib>=1.7.1
 argon2-cffi>=16.3.0
 numpy
-plotly>=2.0.15
+plotly==2.0.15
 pyyaml
 
 


### PR DESCRIPTION
Pip installs an rc of plotly, which changes the module structure around. Use v2.0.15 until that solidifies.