### PR TITLE
Persistent docker data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL authors="phil.ewels@scilifelab.se,denis.moreno@scilifelab.se" \
 RUN apt-get update && apt-get install git -y && \
     apt-get install python2.7 -y && \
     apt-get install python2.7-dev -y && \
+    apt-get install libyaml-dev -y && \
     apt-get install libffi-dev -y && \
     apt-get install libpng-dev -y && \
     apt-get install libfreetype6-dev -y && \
@@ -37,11 +38,15 @@ RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /opt/get-pip.py && \
     python /opt/get-pip.py && \
     rm /opt/get-pip.py
 
-# Install PostreSQL
+# Install PostgreSQL and psycopg2
 RUN apt-get install postgresql-9.6 postgresql-server-dev-9.6 -y
+RUN pip install psycopg2-binary
 
 # Set data directory
 ENV PGDATA /usr/local/lib/postgresql
+
+# Tell MegaQC to use postgres / psycopg2
+ENV MEGAQC_PRODUCTION 1
 
 # create the data directory
 RUN mkdir $PGDATA
@@ -66,6 +71,9 @@ RUN python setup.py install
 RUN su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl -D $PGDATA -w start" && \
     megaqc initdb && \
     su postgres -c "/usr/lib/postgresql/9.6/bin/pg_ctl -D $PGDATA -w stop"
+
+# Use volumes to persist logs and data
+VOLUME ["/var/log/postgresql", "/usr/local/lib/postgresql"]
 
 # Run the MegaQC server
 EXPOSE 80

--- a/docs/installation-docker.md
+++ b/docs/installation-docker.md
@@ -1,14 +1,5 @@
 # MegaQC Installation: Docker
 
-## Warning - data persistence
-Whilst running a production instance of MegaQC using docker
-is very easy, note that the database is stored _within_ the
-docker container by default. This means that if the container
-is lost, all data is lost with it.
-
-More instructions about how to set up docker in such a way that
-this doesn't happen hopefully coming soon.
-
 ## Pulling the docker image from dockerhub
 To run MegaQC with docker, simply use the following command:
 
@@ -50,4 +41,66 @@ You can then run MegaQC as described above:
 
 ```bash
 docker run -p 80:80 ewels/megaqc
+```
+
+## Using persistent data
+The Dockerfile has been configured to automatically create persisent volumes
+for the data and log directories. This volume will be created without
+additional input by the user, but if you want to re-use those volumes with a
+new container you must specify them when running the docker image.
+
+The easiest way to ensure the database persists between container states is to
+always specify the same volume for `/usr/local/lib/postgresql`. If a volume is
+found with that name it is used, otherwise it creates a new volume.
+
+To create or re-use a docker volume named `pg_data`:
+```bash
+docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql ewels/megaqc
+```
+
+The same can be done for a log directory volume called `pg_logs`
+```bash
+docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql -v pg_logs:/var/log/postgresql ewels/megaqc
+```
+
+If you did not specify a volume name, docker will have given it a long hex string
+as a unique name. If you do not use volumes frequently, you can check the output
+from `docker volume ls` and `docker volume inspect $VOLUME_NAME`. However, the
+easiest way is to inspect the docker container.
+
+```bash
+# ugly default docker output
+docker inspect --format '{{json .Mounts}}' example_container
+
+# use jq for pretty formatting
+docker inspect --format '{{json .Mounts}}' example_container | jq
+
+# or use python for pretty formatting
+docker inspect --format '{{json .Mounts}}' example_container | python -m json.tool
+```
+
+Example output for the above, nicely formatted:
+```json
+[
+  {
+    "Type": "volume",
+    "Name": "7c8c9dfbcc66874b472676659dde6a5c8e15dea756a620435c83f5980c21d804",
+    "Source": "/var/lib/docker/volumes/7c8c9dfbcc66874b472676659dde6a5c8e15dea756a620435c83f5980c21d804/_data",
+    "Destination": "/usr/local/lib/postgresql",
+    "Driver": "local",
+    "Mode": "",
+    "RW": true,
+    "Propagation": ""
+  },
+  {
+    "Type": "volume",
+    "Name": "6d48d24a660d078dfe4c04960aeb1848ea688a3eae0d4b7b54b1043f7885e428",
+    "Source": "/var/lib/docker/volumes/6d48d24a660d078dfe4c04960aeb1848ea688a3eae0d4b7b54b1043f7885e428/_data",
+    "Destination": "/var/log/postgresql",
+    "Driver": "local",
+    "Mode": "",
+    "RW": true,
+    "Propagation": ""
+  }
+]
 ```


### PR DESCRIPTION
Main functionality gain here is using volumes to persist data after the docker container closes. An additional bugfix setting the `MEGAQC_PRODUCTION` environment variable so that MegaQC inits the right db.