### PR TITLE
increase default log verbosity, add some logs for upload processing

### DIFF
--- a/megaqc/app.py
+++ b/megaqc/app.py
@@ -5,13 +5,15 @@ This file contains the app module, with the app factory function."""
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
+
 from flask import Flask, jsonify, render_template, request
 import jinja2
 import markdown
-from megaqc.scheduler import init_scheduler
+import logging
 
 from megaqc import commands, public, user, version, api
 from megaqc.extensions import cache, csrf_protect, db, debug_toolbar, login_manager
+from megaqc.scheduler import init_scheduler
 from megaqc.settings import ProdConfig, TestConfig
 
 def create_app(config_object):
@@ -20,6 +22,9 @@ def create_app(config_object):
     :param config_object: The configuration object to use.
     """
     app = Flask(__name__.split('.')[0])
+    # get appropriate log level from config and set it
+    log_level = getattr(config_object, 'LOG_LEVEL', logging.INFO)
+    app.logger.setLevel(log_level)
     app.config.from_object(config_object)
     if app.config['SERVER_NAME'] is not None:
         print(" * Server name: {}".format(app.config['SERVER_NAME']))

--- a/megaqc/settings.py
+++ b/megaqc/settings.py
@@ -2,8 +2,11 @@
 """Application configuration."""
 from __future__ import print_function
 from builtins import object
-import os
+
 from megaqc.scheduler import upload_reports_job
+
+import logging
+import os
 import yaml
 
 
@@ -23,6 +26,7 @@ class Config(object):
     EXTRA_CONFIG = os.environ.get("MEGAQC_CONFIG", None)
     SERVER_NAME = None
     DB_PATH = None
+    LOG_LEVEL = logging.INFO
     SQLALCHEMY_DBMS = None
     SQLALCHEMY_HOST = 'localhost:5432'
     SQLALCHEMY_USER = 'megaqc_user'
@@ -97,6 +101,7 @@ class DevConfig(Config):
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
     WTF_CSRF_ENABLED = False  # Allows form testing
     SQLALCHEMY_RECORD_QUERIES = True
+    LOG_LEVEL = logging.DEBUG
 
     def __init__(self):
         super(DevConfig, self).__init__()
@@ -115,6 +120,7 @@ class TestConfig(Config):
     DB_NAME = 'test.db'
     DB_PATH = os.path.join(Config.PROJECT_ROOT, DB_NAME)
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
+    LOG_LEVEL = logging.DEBUG
 
     def __init__(self):
         super(TestConfig, self).__init__()


### PR DESCRIPTION
Logging was pretty minimal (basic access) and `logLevel` was set to WARN so debug/info messages weren't being shown. Set production default to `INFO`, everything else to `DEBUG`. Once things are more stable it'll be a good idea to switch prod log level back to `WARN`, but right now the extra visibility outweighs the log noise.

Also put in some extra logs around upload processing to try and track down some weirdness we're seeing.