### PR TITLE
Filtering fixes

### DIFF
--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -1280,7 +1280,7 @@ def get_filter_from_data(data):
         if filter_id == -1:
             my_filter = []
         else:
-            my_filter = json.loads(db.session.query(SampleFilter.sample_filter_data).filter(SampleFilter.sample_filter_id == filter_id).first())
+            my_filter = json.loads(db.session.query(SampleFilter.sample_filter_data).filter(SampleFilter.sample_filter_id == filter_id).first()[0])
     else:
         my_filter = data.get("filters", [])
 

--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -199,7 +199,7 @@ def handle_report_data(user, report_data):
             if report_data['report_plot_data'][plot]['plot_type'] == "bar_graph":
 
                 for sub_dict in dataset:
-                    data_key = sub_dict['name']
+                    data_key = str(sub_dict['name'])
                     existing_category = db.session.query(PlotCategory).filter(PlotCategory.category_name==data_key).first()
                     data = json.dumps({x:y for x,y in list(sub_dict.items()) if x != 'data'})
                     if not existing_category:

--- a/megaqc/app.py
+++ b/megaqc/app.py
@@ -3,14 +3,14 @@
 This file contains the app module, with the app factory function."""
 
 from __future__ import print_function
+from builtins import str
 from future import standard_library
 standard_library.install_aliases()
 
-from flask import Flask, jsonify, render_template, request
 import jinja2
 import markdown
-import logging
 
+from flask import Flask, jsonify, render_template, request
 from megaqc import commands, public, user, version, api
 from megaqc.extensions import cache, csrf_protect, db, debug_toolbar, login_manager
 from megaqc.scheduler import init_scheduler
@@ -22,9 +22,6 @@ def create_app(config_object):
     :param config_object: The configuration object to use.
     """
     app = Flask(__name__.split('.')[0])
-    # get appropriate log level from config and set it
-    log_level = getattr(config_object, 'LOG_LEVEL', logging.INFO)
-    app.logger.setLevel(log_level)
     app.config.from_object(config_object)
     if app.config['SERVER_NAME'] is not None:
         print(" * Server name: {}".format(app.config['SERVER_NAME']))
@@ -72,14 +69,15 @@ def register_errorhandlers(app):
         """Render error template."""
         # If a HTTPException, pull the `code` attribute; default to 500
         error_code = getattr(error, 'code', 500)
+        err_msg = str(error)
         # Return JSON if an API call
         if request.path.startswith('/api/'):
             response = jsonify({
                 'success': False,
-                'message': getattr(error, 'description'),
+                'message': err_msg,
                 'error': {
                     'code': error_code,
-                    'message': getattr(error, 'description')
+                    'message': err_msg
                 }
             })
             response.status_code = error_code

--- a/megaqc/public/views.py
+++ b/megaqc/public/views.py
@@ -194,7 +194,7 @@ def edit_filters():
     for sfg in sample_filters:
         sample_filter_counts[sfg] = {}
         for sf in sample_filters[sfg]:
-            sample_filter_counts[sf['id']] = get_samples(filters=sf['id'], count=True)
+            sample_filter_counts[sf['id']] = get_samples(filters=sf.get('sample_filter_data', []), count=True)
     return render_template(
         'users/organize_filters.html',
         sample_filters = sample_filters,

--- a/megaqc/scheduler.py
+++ b/megaqc/scheduler.py
@@ -49,9 +49,8 @@ def upload_reports_job():
                 # Now save the parsed JSON data to the database
                 ret = handle_report_data(user, data)
             except Exception:
-                current_app.logger.error("Failed loading upload {}: {}".format(row.upload_id, traceback.format_exc()))
                 ret = (False, '<pre><code>{}</code></pre>'.format(traceback.format_exc()))
-                current_app.logger.error("Error processing upload {}: {}".format(row.upload_id, ret))
+                current_app.logger.error("Error processing upload {}: {}".format(row.upload_id, traceback.format_exc()))
             if ret[0]:
                 row.status = "TREATED"
                 row.message = "The document has been uploaded successfully"

--- a/megaqc/scheduler.py
+++ b/megaqc/scheduler.py
@@ -49,6 +49,7 @@ def upload_reports_job():
                 # Now save the parsed JSON data to the database
                 ret = handle_report_data(user, data)
             except Exception:
+                current_app.logger.error("Failed loading upload {}: {}".format(row.upload_id, traceback.format_exc()))
                 ret = (False, '<pre><code>{}</code></pre>'.format(traceback.format_exc()))
                 current_app.logger.error("Error processing upload {}: {}".format(row.upload_id, ret))
             if ret[0]:


### PR DESCRIPTION
Fixes include:
* #18 - `edit_filters` view was sending the wrong values to `build_filters` so the page was just throwing 500
* Filters were create-able from the plot view pages, but attempting to use one failed out. JSON serialization problem there.
* plots where the key value was numeric caused data loads to fail, as it was expecting a varchar, so that is cast to `str`
* better error string on failed upload

While #18 is fixed, the sample counts being returned for the filters on that page are incorrect. However, the filters function as desired when used in the plot views, so it's just something in how the count is generated. Will make a followup issue for that later.