### PR TITLE
Assorted db-related fixes

### DIFF
--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -90,7 +90,7 @@ def handle_report_data(user, report_data):
         new_report.save()
     except InvalidRequestError as e:
         if 'UNIQUE constraint failed' in str(e):
-            return (False, 'Report already uploaded')
+            return (False, 'Report already processed')
         else:
             raise e
     current_app.logger.info("Created new report {} from {}".format(new_report.report_id, user.email))

--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -250,7 +250,7 @@ def handle_report_data(user, report_data):
                     else:
                         existing_category.data = data
                         existing_category.save()
-                        category_id = existing_category.plot_category_id
+                    category_id = existing_category.plot_category_id
 
                     for sa_idx, actual_data in enumerate(sub_dict['data']):
                         sample = db.session.query(Sample).filter(Sample.sample_name==sub_dict['name']).first()

--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -255,8 +255,8 @@ def handle_report_data(user, report_data):
                     for sa_idx, actual_data in enumerate(sub_dict['data']):
                         sample = db.session.query(Sample).filter(Sample.sample_name==sub_dict['name']).first()
                         if not sample:
-                            new_sample = Sample(sample_name=sub_dict['name'], report_id=report_id)
-                            new_sample.save()
+                            sample = Sample(sample_name=sub_dict['name'], report_id=report_id)
+                            sample.save()
                         sample_id = sample.sample_id
 
                         new_dataset_row = PlotData(

--- a/megaqc/api/views.py
+++ b/megaqc/api/views.py
@@ -236,7 +236,7 @@ def save_filters(user, *args, **kwargs):
         return jsonify({
                 'success': True,
                 'message': "Filters created successfully",
-                'filter_id': new_sf_id
+                'filter_id': new_sf.sample_filter_id
             })
     else:
         return jsonify({

--- a/megaqc/model/models.py
+++ b/megaqc/model/models.py
@@ -26,7 +26,7 @@ class Report(db.Model, CRUDMixin):
     __tablename__ = 'report'
     report_id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey('users.user_id'), index=True)
-    report_hash = Column(Unicode, index=True)
+    report_hash = Column(Unicode, index=True, unique=True)
     created_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
     uploaded_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
 

--- a/megaqc/scheduler.py
+++ b/megaqc/scheduler.py
@@ -56,6 +56,9 @@ def upload_reports_job():
                 row.message = "The document has been uploaded successfully"
                 os.remove(row.path)
             else:
+                if ret[1] == "Report already processed":
+                    current_app.logger.info("Upload {} already being processed by another worker, skipping".format(row.upload_id))
+                    continue
                 row.status = "FAILED"
                 row.message = "The document has not been uploaded : {0}".format(ret[1])
             row.modified_at = datetime.datetime.utcnow()


### PR DESCRIPTION
Found a few new ID references that got missed on the first pass that would cause issues when creating new filters or samples.

Also put in the unique index and try/except block for report insertion to make it harder for multiple workers to insert the same data multiple times (see #64). If a scheduler process passes the first unique check but fails on insert it will continue on to the next queued upload. That way it won't be erroneously marked as failed while being processed elsewhere.