### PR TITLE
Renamed MEGAQC_DEBUG to FLASK_DEBUG and tidied config profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ uploads/*
 
 # Development stuff
 dev.db
+test.db
 dist/
 
 # Dev CSS

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ uploads/*
 # Development stuff
 dev.db
 test.db
+megaqc.db
 dist/
 
 # Dev CSS

--- a/docs/installation-dev.md
+++ b/docs/installation-dev.md
@@ -26,20 +26,20 @@ conda install -c bioconda megaqc
 ```
 
 ## 2. (Optional) Set the variable for the development mode:
-Setting this bash variable tells MegaQC to show full Python exception
-tracebacks in the web browser, as well as additional Flask plugins
-which help with debugging and performance testing.
+Setting this bash variable runs MegaQC in development mode. This means
+that it will show full Python exception tracebacks in the web browser
+as well as additional Flask plugins which help with debugging and performance testing.
 
 This is only useful when actively developing MegaQC code and should
 be skipped if you're just trying MegaQC out.
 
 ```bash
-export MEGAQC_DEBUG=1
+export FLASK_DEBUG=1
 ```
 
 ## 3. Set up the database
 Running this command creates an empty SQLite MegaQC database file in the
-installation directory called `dev.db`.
+installation directory called `test.db` (`dev.db` if running in dev mode).
 
 ```bash
 megaqc initdb

--- a/docs/installation-dev.md
+++ b/docs/installation-dev.md
@@ -39,7 +39,7 @@ export FLASK_DEBUG=1
 
 ## 3. Set up the database
 Running this command creates an empty SQLite MegaQC database file in the
-installation directory called `test.db` (`dev.db` if running in dev mode).
+installation directory called `megaqc.db`
 
 ```bash
 megaqc initdb

--- a/megaqc/settings.py
+++ b/megaqc/settings.py
@@ -93,7 +93,7 @@ class DevConfig(Config):
     ENV = 'dev'
     DEBUG = True
     SQLALCHEMY_DBMS = 'sqlite'
-    DB_NAME = 'dev.db'
+    DB_NAME = 'megaqc.db'
     # Put the db file in project root
     DB_PATH = os.path.join(Config.PROJECT_ROOT, DB_NAME)
     DEBUG_TB_ENABLED = True
@@ -116,7 +116,7 @@ class TestConfig(Config):
     """Test configuration."""
     DEBUG = False
     SQLALCHEMY_DBMS = 'sqlite'
-    DB_NAME = 'test.db'
+    DB_NAME = 'megaqc.db'
     DB_PATH = os.path.join(Config.PROJECT_ROOT, DB_NAME)
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     LOG_LEVEL = logging.DEBUG

--- a/megaqc/settings.py
+++ b/megaqc/settings.py
@@ -67,7 +67,6 @@ class Config(object):
                 self.SQLALCHEMY_DATABASE
             )
 
-
 class ProdConfig(Config):
     """Production configuration."""
 
@@ -83,7 +82,7 @@ class ProdConfig(Config):
         super(ProdConfig, self).__init__()
         self.update_db_uri()
         # Log to the terminal
-        print("Env: Prod")
+        print(" * Environment: Prod")
         print(" * Database type: {}".format(self.SQLALCHEMY_DBMS))
         print(" * Database path: {}".format(self.SQLALCHEMY_DATABASE_URI_SAN))
 
@@ -107,7 +106,7 @@ class DevConfig(Config):
         super(DevConfig, self).__init__()
         self.update_db_uri()
         # Log to the terminal
-        print("Env: dev")
+        print(" * Environment: dev")
         print(" * Database type: {}".format(self.SQLALCHEMY_DBMS))
         print(" * Database path: {}".format(self.SQLALCHEMY_DATABASE_URI_SAN))
 
@@ -126,6 +125,6 @@ class TestConfig(Config):
         super(TestConfig, self).__init__()
         self.update_db_uri()
         # Log to the terminal
-        print("Env: test")
+        print(" * Environment: test")
         print(" * Database type: {}".format(self.SQLALCHEMY_DBMS))
         print(" * Database path: {}".format(self.SQLALCHEMY_DATABASE_URI_SAN))

--- a/megaqc/wsgi.py
+++ b/megaqc/wsgi.py
@@ -3,7 +3,7 @@ from megaqc.app import create_app
 from megaqc.settings import TestConfig, DevConfig, ProdConfig
 
 
-if os.environ.get('MEGAQC_DEBUG', False):
+if os.environ.get('FLASK_DEBUG', False):
     CONFIG = DevConfig()
 elif os.environ.get('MEGAQC_PRODUCTION', False):
     CONFIG = ProdConfig()

--- a/scripts/megaqc
+++ b/scripts/megaqc
@@ -4,6 +4,7 @@
 """
 
 import click
+import os
 from flask.cli import FlaskGroup
 
 def create_megaqc_app(info):
@@ -11,7 +12,7 @@ def create_megaqc_app(info):
     from megaqc.app import create_app
     from megaqc.settings import TestConfig, DevConfig, ProdConfig
 
-    if os.environ.get('MEGAQC_DEBUG', False):
+    if os.environ.get('FLASK_DEBUG', False):
         CONFIG = DevConfig()
     elif os.environ.get('MEGAQC_PRODUCTION', False):
         CONFIG = ProdConfig()
@@ -30,4 +31,9 @@ if __name__ == '__main__':
     import pkg_resources
     version = pkg_resources.get_distribution("megaqc").version
     print("This is MegaQC v{}\n".format(version))
+    if os.environ.get('FLASK_DEBUG', False):
+        print(' * Environment variable FLASK_DEBUG is true - running in dev mode')
+        os.environ['FLASK_ENV'] = 'dev'
+    elif not os.environ.get('MEGAQC_PRODUCTION', False):
+        os.environ['FLASK_ENV'] = 'test'
     cli()


### PR DESCRIPTION
This is quite a simple change (it's all I can manage), but hopefully makes the different config profiles a little clearer.

* Got rid of `MEGAQC_DEBUG` - it seems that `FLASK_DEBUG` has a bunch of built-in stuff that is difficult to get around, so may as well have just one env var instead of two
* Improved logging a bit to try and make stuff clearer.

I did this because it annoyed me that most of the debug options weren't working with only `MEGAQC_DEBUG` set.

I had also hoped to hide the debug sidebar thing in the testing mode, but I can't figure this out and it's time to go to bed now.