### PR TITLE
Clarify psycopq2 dependency for psycopq2 >= 2.8

### DIFF
--- a/docs/installation-prod.md
+++ b/docs/installation-prod.md
@@ -47,6 +47,8 @@ Then, install the Python package that handles requests:
 pip install psycopg2
 ```
 
+(`psycopq2-binary` for psycopq v2.8 and above)
+
 MegaQC can assess whether the database to use is `postgresql`. If it is, it will try to connect as `megaqc_user` to the database `megaqc` on `localhost:5432`. On failure, MegaQC will attempt to create the user and the database, and will then export the schema.
 
 In order to make this happen, run :


### PR DESCRIPTION
I believe that as of psycopq2 v2.8 it is `psycopq2-binary` that needs to be installed