### PR TITLE
Alert model and API

### DIFF
--- a/megaqc/api/views.py
+++ b/megaqc/api/views.py
@@ -4,7 +4,7 @@ from flask import Blueprint, request, jsonify, abort
 
 from megaqc.extensions import db
 from megaqc.user.models import User
-from megaqc.model.models import PlotData, Report, SampleFilter, PlotFavourite, Dashboard
+from megaqc.model.models import PlotData, Report, SampleFilter, PlotFavourite, Dashboard, AlertThreshold
 from megaqc.api.utils import handle_report_data, generate_report_plot, generate_distribution_plot, \
                             generate_trend_plot, generate_comparison_plot, get_samples, get_report_metadata_fields, \
                             get_sample_metadata_fields, aggregate_new_parameters, get_user_filters, update_fav_report_plot_type, \
@@ -452,3 +452,21 @@ def count_queued_uploads():
             'success': True,
             'count': count
             })
+
+@api_blueprint.route('/api/save_alert_threshold', methods=['POST'])
+@check_user
+def save_alert_threshold(user, *args, **kwargs):
+    data = request.get_json()
+    AlertThreshold.create(threshold=data['filters'], name=data['meta']['name'], description=data['meta']['description'])
+    return jsonify({
+        'success': True
+    })
+
+@api_blueprint.route('/api/get_alert_thresholds', methods=['POST'])
+@check_user
+def get_alert_thresholds(user, *args, **kwargs):
+    data = AlertThreshold.query().all()
+    return jsonify({
+        'success': True,
+        'thresholds': data
+    })

--- a/megaqc/model/models.py
+++ b/megaqc/model/models.py
@@ -138,12 +138,14 @@ class Sample(db.Model, CRUDMixin):
         sample_alerts = [alert for alert in db.session.query(AlertThreshold).all() if alert.sample_id == self.sample_id]
         db.session.bulk_save_objects(sample_alerts)
 
-@event.listens_for(Sample, 'alert_insert')
+
+@event.listens_for(Sample, 'after_insert')
 def new_alert_threshold(mapper, connection, target: Sample):
     """
     Whenever a Sample is inserted into the DB, create Alerts for it
     """
     target.generate_alerts()
+
 
 class SampleFilter(db.Model, CRUDMixin):
     __tablename__ = "sample_filter"
@@ -193,7 +195,7 @@ class AlertThreshold(db.Model, CRUDMixin):
         db.session.bulk_save_objects(self.calculate_alerts())
 
 
-@event.listens_for(AlertThreshold, 'alert_insert')
+@event.listens_for(AlertThreshold, 'after_insert')
 def new_alert_threshold(mapper, connection, target: AlertThreshold):
     """
     Whenever an AlertThreshold is inserted into the DB, create Alerts for it

--- a/megaqc/model/models.py
+++ b/megaqc/model/models.py
@@ -1,23 +1,28 @@
 # -*- coding: utf-8 -*-
 import datetime as dt
 
+from sqlalchemy import event
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Table, ForeignKey, Column, Boolean, Integer, Float, Unicode, TIMESTAMP, Binary, DateTime, func
+from sqlalchemy import JSON
+import enum
 
 from megaqc.database import CRUDMixin
 from megaqc.extensions import db
 
+import megaqc.api.utils
 
 user_plotconfig_map = db.Table('user_plotconfig_map',
-            db.Column('user_id', Integer, db.ForeignKey('users.user_id')),
-            db.Column('plot_config_id', Integer, db.ForeignKey('plot_config.config_id'))
-            )
+                               db.Column('user_id', Integer, db.ForeignKey('users.user_id')),
+                               db.Column('plot_config_id', Integer, db.ForeignKey('plot_config.config_id'))
+                               )
 
 user_sampletype_map = db.Table('user_sampletype_map',
-            db.Column('user_id', Integer, db.ForeignKey('users.user_id')),
-            db.Column('sample_data_type_id', Integer, db.ForeignKey('sample_data_type.sample_data_type_id'))
-            )
+                               db.Column('user_id', Integer, db.ForeignKey('users.user_id')),
+                               db.Column('sample_data_type_id', Integer,
+                                         db.ForeignKey('sample_data_type.sample_data_type_id'))
+                               )
 
 
 class Report(db.Model, CRUDMixin):
@@ -50,7 +55,7 @@ class ReportMeta(db.Model, CRUDMixin):
 class PlotConfig(db.Model, CRUDMixin):
     __tablename__ = 'plot_config'
     config_id = Column(Integer, primary_key=True)
-    config_type = Column(Unicode,  nullable=False)
+    config_type = Column(Unicode, nullable=False)
     config_name = Column(Unicode, nullable=False)
     config_dataset = Column(Unicode, nullable=True)
     data = Column(Unicode, nullable=False)
@@ -122,6 +127,23 @@ class Sample(db.Model, CRUDMixin):
     sample_name = Column(Unicode)
     report_id = Column(Integer, ForeignKey('report.report_id'), index=True)
 
+    alerts = relationship("Alert", back_populates='sample')
+
+    def generate_alerts(self):
+        """
+        Triggers any alerts that should be created by the creation of this sample
+        """
+
+        # This is awful and the sample filtering should be done in the database
+        sample_alerts = [alert for alert in db.session.query(AlertThreshold).all() if alert.sample_id == self.sample_id]
+        db.session.bulk_save_objects(sample_alerts)
+
+@event.listens_for(Sample, 'alert_insert')
+def new_alert_threshold(mapper, connection, target: Sample):
+    """
+    Whenever a Sample is inserted into the DB, create Alerts for it
+    """
+    target.generate_alerts()
 
 class SampleFilter(db.Model, CRUDMixin):
     __tablename__ = "sample_filter"
@@ -142,3 +164,50 @@ class Upload(db.Model, CRUDMixin):
     created_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
     modified_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
     user_id = Column(Integer, ForeignKey('users.user_id'))
+
+
+class AlertThreshold(db.Model, CRUDMixin):
+    __tablename__ = "alert_threshold"
+    alert_threshold_id = Column(Integer, primary_key=True)
+    threshold = Column(JSON)
+    name = Column(Unicode)
+    description = Column(Unicode)
+    created_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
+    modified_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
+    importance = Column(Integer)
+
+    alerts = relationship("Alert", back_populates='threshold')
+
+    def calculate_alerts(self):
+        """
+        Triggers any Alerts that should be created by the creation of this alert
+        """
+        samples = megaqc.api.utils.get_samples(self.threshold)
+        alerts = [Alert(sample=sample, threshold=self, message='') for sample in samples]
+        return alerts
+
+    def generate_alerts(self):
+        """
+        Creates any Alerts that should be created by the creation of this alert
+        """
+        db.session.bulk_save_objects(self.calculate_alerts())
+
+
+@event.listens_for(AlertThreshold, 'alert_insert')
+def new_alert_threshold(mapper, connection, target: AlertThreshold):
+    """
+    Whenever an AlertThreshold is inserted into the DB, create Alerts for it
+    """
+    target.generate_alerts()
+
+
+class Alert(db.Model, CRUDMixin):
+    __tablename__ = "alert"
+    alert_id = Column(Integer, primary_key=True)
+    alert_threshold_id = Column(Integer, ForeignKey('alert_threshold.alert_threshold_id'), index=True)
+    sample_id = Column(Integer, ForeignKey('sample.sample_id'), index=True)
+    message = Column(Unicode)
+    created_at = Column(DateTime, nullable=False, default=dt.datetime.utcnow)
+
+    threshold = relationship("AlertThreshold", back_populates='alerts')
+    sample = relationship("Sample", back_populates='alerts')


### PR DESCRIPTION
Relates to #28. This is a basic implementation of alerts and thresholds that we can use to discuss the data model. To actually make this usable we would need:
- a page for creating/editing thresholds
- a page for viewing alerts
- the ability to add simple thresholds onto trend/control charts