### PR TITLE
Do not use underscore in access-token header

### DIFF
--- a/megaqc/api/views.py
+++ b/megaqc/api/views.py
@@ -26,7 +26,7 @@ api_blueprint = Blueprint('api', __name__, static_folder='../static')
 def check_user(function):
     @wraps(function)
     def user_wrap_function(*args, **kwargs):
-        user = User.query.filter_by(api_token=request.headers.get("access_token")).first()
+        user = User.query.filter_by(api_token=request.headers.get("access-token")).first()
         if not user:
             abort(403) # if no user, abort the request with 403
         kwargs['user'] = user
@@ -36,7 +36,7 @@ def check_user(function):
 def check_admin(function):
     @wraps(function)
     def user_wrap_function(*args, **kwargs):
-        user = User.query.filter_by(api_token=request.headers.get("access_token")).first()
+        user = User.query.filter_by(api_token=request.headers.get("access-token")).first()
         if not user or not user.is_admin:
             abort(403) # if no user, abort the request with 403
         kwargs['user'] = user

--- a/megaqc/static/js/admin.js
+++ b/megaqc/static/js/admin.js
@@ -22,7 +22,7 @@ function init_buttons(){
             url:"/api/update_users",
             type: 'post',
             data:JSON.stringify(data),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(){
@@ -47,7 +47,7 @@ function init_buttons(){
             url:"/api/delete_users",
             type: 'post',
             data:JSON.stringify(data),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(){
@@ -71,7 +71,7 @@ function init_buttons(){
             url:"/api/reset_password",
             type: 'post',
             data:JSON.stringify(data),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(data){
@@ -107,7 +107,7 @@ function init_buttons(){
             url:"/api/add_user",
             type: 'post',
             data: JSON.stringify(data),
-            headers: {access_token:window.token},
+            headers: {access-token:window.token},
             dataType: 'json',
             contentType: "application/json; charset=UTF-8",
             success: function(ret_data){

--- a/megaqc/static/js/filter_samples.js
+++ b/megaqc/static/js/filter_samples.js
@@ -192,7 +192,7 @@ $(function(){
             url: '/api/report_filter_fields',
             type: 'post',
             data:JSON.stringify( {'filters': window.active_filters} ),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){
@@ -296,7 +296,7 @@ $(function(){
             url: '/api/save_filters',
             type: 'post',
             data:JSON.stringify(new_filters),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/static/js/megaqc.js
+++ b/megaqc/static/js/megaqc.js
@@ -33,7 +33,7 @@ function save_plot_favourite(plot_type, request_data){
             'title': $('#plot_favourite_title').val(),
             'description': $('#plot_favourite_description').val()
         }),
-        headers : { access_token:window.token },
+        headers : { access-token:window.token },
         dataType: 'json',
         contentType: 'application/json; charset=UTF-8',
         success: function(data){

--- a/megaqc/static/js/members.js
+++ b/megaqc/static/js/members.js
@@ -13,7 +13,7 @@ $("#password_submit").click(function(e){
             url:"/api/set_password",
             type: 'post',
             data:JSON.stringify(data),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(data){

--- a/megaqc/static/js/plot_choice.js
+++ b/megaqc/static/js/plot_choice.js
@@ -20,7 +20,7 @@ function init_report_checkboxes(){
             url:"/api/get_samples_per_report",
             type: 'post',
             data:JSON.stringify({"report_id":report_id}),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(data){
@@ -49,7 +49,7 @@ function init_btns(){
             url:"/api/get_report_plot",
             type: 'post',
             data:JSON.stringify({"samples":selected_samples, "plot_type":window.graph_type}),
-            headers : {access_token:window.token},
+            headers : {access-token:window.token},
             dataType: 'json',
             contentType:"application/json; charset=UTF-8",
             success: function(json){

--- a/megaqc/templates/public/comparisons.html
+++ b/megaqc/templates/public/comparisons.html
@@ -243,7 +243,7 @@ $(function(){
                 'pointsize': $('#pointsize').val(),
                 'joinmarkers': $('#joinmarkers').is(':checked')
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/public/dashboard.html
+++ b/megaqc/templates/public/dashboard.html
@@ -56,7 +56,7 @@ $(function () {
             url: '/api/get_favourite_plot',
             type: 'post',
             data: JSON.stringify({'favourite_id': el.data('plotid') }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/public/distributions.html
+++ b/megaqc/templates/public/distributions.html
@@ -211,7 +211,7 @@ $(function(){
                 'nbins': window.hist_nbins,
                 'ptype': window.dist_ptype
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/public/report_plot.html
+++ b/megaqc/templates/public/report_plot.html
@@ -77,7 +77,7 @@ $(function(){
             url: '/api/report_filter_fields',
             type: 'post',
             data:JSON.stringify( { "filters_id": filter_id }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){
@@ -179,7 +179,7 @@ $(function(){
             url: '/api/update_favourite_plot',
             type: 'post',
             data:JSON.stringify(pdata),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){
@@ -241,7 +241,7 @@ $(function(){
                 'filters_id': $('.sample-filter-btn.active').first().data('filterid'),
                 'plot_type': plot_type
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/public/reports_management.html
+++ b/megaqc/templates/public/reports_management.html
@@ -78,7 +78,7 @@ function init_filter(){
                     'key':$('#report_filter_select').val(),
                     'value':$('#report_filter_input').val()
                 }),
-                headers : { access_token:window.token },
+                headers : { access-token:window.token },
                 dataType: 'json',
                 contentType: 'application/json; charset=UTF-8',
                 success: function(data){
@@ -116,7 +116,7 @@ function init_buttons(){
             data: JSON.stringify( {
                 'report_id': report_id
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/public/trends.html
+++ b/megaqc/templates/public/trends.html
@@ -172,7 +172,7 @@ $(function(){
                 'filters_id': $('.sample-filter-btn.active').first().data('filterid'),
                 'fields': field_ids
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/users/create_dashboard.html
+++ b/megaqc/templates/users/create_dashboard.html
@@ -254,7 +254,7 @@ $(function () {
             url: '/api/get_favourite_plot',
             type: 'post',
             data: JSON.stringify({'favourite_id': plot_id }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){
@@ -412,7 +412,7 @@ $(function () {
                 'data': serializedData,
                 'is_public': false
             }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){

--- a/megaqc/templates/users/multiqc_config.html
+++ b/megaqc/templates/users/multiqc_config.html
@@ -26,7 +26,7 @@
       Test connection command
     </div>
     <div class="card-body">
-      <pre><code id="api_key_test_cmd">curl -H "access_token: {{current_user.api_token}}" -H "Content-Type: application/json" {{url_for('api.test', _external=True)}}</code></pre>
+      <pre><code id="api_key_test_cmd">curl -H "access-token: {{current_user.api_token}}" -H "Content-Type: application/json" {{url_for('api.test', _external=True)}}</code></pre>
     </div>
   </div>
   <p>You should get a response that looks like this:</p>

--- a/megaqc/templates/users/plot_favourites.html
+++ b/megaqc/templates/users/plot_favourites.html
@@ -67,7 +67,7 @@ $(function(){
             url: '/api/delete_plot_favourite',
             type: 'post',
             data: JSON.stringify({'favourite_id': fav_id }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){
@@ -104,7 +104,7 @@ $(function(){
             url: '/api/get_favourite_plot',
             type: 'post',
             data: JSON.stringify({'favourite_id': $(this).data('favouriteid') }),
-            headers : { access_token:window.token },
+            headers : { access-token:window.token },
             dataType: 'json',
             contentType: 'application/json; charset=UTF-8',
             success: function(data){


### PR DESCRIPTION
Nginx defaults to stripping underscore from http headers. This is behavior is rather confusing, so in order to save others from the headache of troubleshooting this, I changed MegaQC to use a `-` instead.

This needs to be synchronized with the way MultiQC (and other clients) call the API. I will add a link to the corresponding PR to MultiQC if you think that this change looks alright. If not, I can just open another PR to add some information about this to the troubleshooting section instead.