### PR TITLE
fixed PyYAML yaml.load(input) Deprecation

### DIFF
--- a/megaqc/settings.py
+++ b/megaqc/settings.py
@@ -46,7 +46,7 @@ class Config(object):
     def __init__(self):
         if self.EXTRA_CONFIG:
             with open(self.EXTRA_CONFIG) as f:
-                self.extra_conf = yaml.load(f)
+                self.extra_conf = yaml.load(f, Loader=yaml.FullLoader)
                 for key in self.extra_conf:
                     if key in Config.__dict__:
                         setattr(self, key, self.extra_conf[key])

--- a/megaqc/utils/settings.py
+++ b/megaqc/utils/settings.py
@@ -80,7 +80,7 @@ def mqc_load_config(yaml_config):
     if os.path.isfile(yaml_config):
         try:
             with io.open(yaml_config) as f:
-                new_config = yaml.load(f)
+                new_config = yaml.load(f, Loader=yaml.FullLoader)
                 logger.debug("Loading config settings from: {}".format(yaml_config))
                 mqc_add_config(new_config, yaml_config)
         except (IOError, AttributeError) as e:
@@ -94,11 +94,11 @@ def mqc_load_config(yaml_config):
 def mqc_cl_config(cl_config):
     for clc_str in cl_config:
         try:
-            parsed_clc = yaml.load(clc_str)
+            parsed_clc = yaml.load(clc_str, Loader=yaml.FullLoader)
             # something:var fails as it needs a space. Fix this (a common mistake)
             if isinstance(parsed_clc, str) and ":" in clc_str:
                 clc_str = ": ".join(clc_str.split(":"))
-                parsed_clc = yaml.load(clc_str)
+                parsed_clc = yaml.load(clc_str, Loader=yaml.FullLoader)
             assert isinstance(parsed_clc, dict)
         except yaml.scanner.ScannerError as e:
             logger.error(

--- a/megaqc/utils/settings.py
+++ b/megaqc/utils/settings.py
@@ -44,7 +44,7 @@ MEGAQC_DIR = os.path.dirname(os.path.realpath(inspect.getfile(megaqc)))
 # Default MegaQC config
 searchp_fn = os.path.join(MEGAQC_DIR, "utils", "config_defaults.yaml")
 with io.open(searchp_fn) as f:
-    configs = yaml.load(f)
+    configs = yaml.load(f, Loader=yaml.FullLoader)
     for c, v in list(configs.items()):
         globals()[c] = v
 


### PR DESCRIPTION
Hi,

every yaml loading call resulted in deprecated warnings.
Details: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

When with FullLoader for now, but could also go for the SafeLoader? (See my link)

Signed-off-by: Zethson <lukas.heumos@posteo.net>