### PR TITLE
added python 3.9 to the build CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hi,

Python 3.9 was released and I am personally using it already in every project where possible.
Hence, I would suggest to add it to MegaQCs CI tests.
Doesn't hurt, since we aren't close to the 20 concurrent jobs limit anyways.

Signed-off-by: Zethson <lukas.heumos@posteo.net>