### PR TITLE
fix node.js error on building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Compile the JS in an isolated container
-FROM node:latest
+FROM node:16.13.0
 COPY . /app
 WORKDIR /app
 RUN npm install


### PR DESCRIPTION
<!-- Many thanks for contributing to MegaQC! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] `docs/changelog.md` is updated

**Description of changes**

Switched from using `node:latest` to `node:16.13.0` to fix #330 that caused a fail in building docker image with node.js v17.2.0

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
