### PR TITLE
Color by categorical in Comparison Plot and fix filters in Report Plot

### DIFF
--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -1464,12 +1464,12 @@ def generate_comparison_plot(
                     norm_plot_size.append(((old_div((x - smin), srange)) * 35) + 2)
                 else:
                     norm_plot_size.append(2)
-            markers["size"] = norm_plot_size
+            markers["size"] = int(norm_plot_size)
             ptitle += '<br><span style="font-size:0.7rem">Marker Size represents "{}"</span>'.format(
                 field_names["size"]
             )
     else:
-        markers["size"] = pointsize
+        markers["size"] = int(pointsize)
 
     plot_height = 600
     if all([x == None for x in plot_z]):

--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -8,7 +8,6 @@ import os
 import random
 import string
 import sys
-import pickle
 import pencils
 import numpy as np
 from builtins import map, range, str
@@ -1396,9 +1395,6 @@ def generate_comparison_plot(
     plot_size = []
     annotations = go.Annotations([])
 
-    # with open('/home/ubuntu/data_dict.pkl', 'wb') as f:
-    #     pickle.dump(plot_data, f)
-
     # Remove any missing values from the plot data recursively
     number_data_including_none = len(plot_data)
 
@@ -1420,9 +1416,6 @@ def generate_comparison_plot(
 
     plot_data = remove_none_vals_from_dict(plot_data)
 
-    # with open('/home/ubuntu/data_dict_afterrm.pkl', 'wb') as f:
-    #     pickle.dump(plot_data, f)
-
     plot_names = plot_data.keys()
     number_removed_data = number_data_including_none - len(plot_data)
     current_app.logger.warn(
@@ -1430,8 +1423,6 @@ def generate_comparison_plot(
             number_removed_data
         )
     )
-    # current_app.logger.warn(f"x {data_keys['x']}")
-    # current_app.logger.warn(f"y {data_keys['y']}")
 
     # Sort the data by the x, y variables (needed when joining dots with lines)
     plot_names = sorted(

--- a/megaqc/api/views.py
+++ b/megaqc/api/views.py
@@ -213,7 +213,8 @@ def get_samples_per_report(user, *args, **kwargs):
 def get_report_plot(user, *args, **kwargs):
     data = request.get_json()
     plot_type = data.get("plot_type")
-    filters = data.get("filters", [])
+    # filters = data.get("filters", [])
+    filters = get_filter_from_data(data)
     sample_names = get_samples(filters)
     html = generate_report_plot(plot_type, sample_names)
     return jsonify({"success": True, "plot": html})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ flapison = "^0.30"
 Flask-Migrate = "^2.5"
 environs = "^9.2.0"
 MarkupSafe = "<2.1.0"
+pencils = "^0.1.0"
 # Testing
 pytest = { version = "^7.2", optional = true }
 WebTest = { version = "^2.0", optional = true }


### PR DESCRIPTION
<!-- Many thanks for contributing to MegaQC! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] If you've fixed a bug or added code that should be tested, add tests!

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

Previously, Report Plots would show all data even when filters were applied ([Issue](https://github.com/ewels/MegaQC/issues/462)), had to change how `get_report_plot` was extracting the filters in order to get the expected behavior where the plots only show samples that pass the applied filters.

In the Comparison Plots, only continuous variables could be used for the color. Added the ability to detect if the color is set to a variable that is categorical (i.e. contains strings) and automatically generate a color scheme based on the unique values.

In the Comparison Plots, if, for example, a user specified an x and y variable and some samples were missing the y variable but had the x variable, the plot would error out. Fixed this by changing `None` to `np.nan`.

Encountered error in Comparison Plots where the point size was not being set as an integer, so casted this variable as an integer.

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

Used the [pencils](https://github.com/orsinium-labs/pencils) package to aid in the automatic generation of color schemes for categoricals. This package contains a large list of unique colors, so it should be sufficient for situations where even hundreds of unique values are present in the categorical variable.

**Additional context**

<!-- Add any other context or screenshots here. -->
