### PR TITLE
Rename ewels/MegaQC -> MultiQC/MegaQC

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -41,7 +41,7 @@ jobs:
       # TODO: We could also build latex & PDF documentation and upload them as artifacts
 
       - name: Deploy
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,9 +19,9 @@ Development
    * Fix a bug in pytest where we used `scope` as a positional argument
    * Update the SubFactoryList to a new version that works with newer FactoryBoy versions
 
-.. _[#430]: https://github.com/ewels/MegaQC/issues/430
-.. _[#440]: https://github.com/ewels/MegaQC/pull/440
-.. _[#433]: https://github.com/ewels/MegaQC/pull/433
+.. _[#430]: https://github.com/MultiQC/MegaQC/issues/430
+.. _[#440]: https://github.com/MultiQC/MegaQC/pull/440
+.. _[#433]: https://github.com/MultiQC/MegaQC/pull/433
 
 =======
 
@@ -87,12 +87,12 @@ Internal Changes
 -  Many and more dependency updates
 
 
-.. _[#69]:  https://github.com/ewels/MegaQC/issues/69
-.. _[#138]: https://github.com/ewels/MegaQC/issues/138
-.. _[#139]: https://github.com/ewels/MegaQC/issues/139
-.. _[#140]: https://github.com/ewels/MegaQC/issues/140
-.. _[#148]: https://github.com/ewels/MegaQC/issues/148
-.. _[#156]: https://github.com/ewels/MegaQC/issues/156
-.. _[#170]: https://github.com/ewels/MegaQC/issues/170
-.. _[#194]: https://github.com/ewels/MegaQC/issues/194
-.. _[#443]: https://github.com/ewels/MegaQC/pull/443
+.. _[#69]:  https://github.com/MultiQC/MegaQC/issues/69
+.. _[#138]: https://github.com/MultiQC/MegaQC/issues/138
+.. _[#139]: https://github.com/MultiQC/MegaQC/issues/139
+.. _[#140]: https://github.com/MultiQC/MegaQC/issues/140
+.. _[#148]: https://github.com/MultiQC/MegaQC/issues/148
+.. _[#156]: https://github.com/MultiQC/MegaQC/issues/156
+.. _[#170]: https://github.com/MultiQC/MegaQC/issues/170
+.. _[#194]: https://github.com/MultiQC/MegaQC/issues/194
+.. _[#443]: https://github.com/MultiQC/MegaQC/pull/443

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ MegaQC is a web application that you can install and run on your own
 network. It collects and visualises data parsed by MultiQC across multiple runs.
 The MegaQC home page looks something like this:
 
-.. figure:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/docs/source/images/megaqc_homepage.png
+.. figure:: https://raw.githubusercontent.com/MultiQC/MegaQC/main/docs/source/images/megaqc_homepage.png
    :alt: MegaQC homepage
 
    Screenshot of the MegaQC home page.
@@ -37,10 +37,10 @@ to learn how to install, deploy and use MegaQC.
 .. _MultiQC website: http://multiqc.info
 .. _GitHub repository: https://github.com/ewels/MultiQC
 
-.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/megaqc/static/img/MegaQC_logo.png
+.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/main/megaqc/static/img/MegaQC_logo.png
 .. |Docker| image:: https://img.shields.io/docker/automated/ewels/megaqc.svg?style=flat-square
    :target: https://hub.docker.com/r/ewels/megaqc/
-.. |Build Status| image:: https://travis-ci.org/ewels/MegaQC.svg?branch=master
+.. |Build Status| image:: https://travis-ci.org/ewels/MegaQC.svg?branch=main
    :target: https://travis-ci.org/ewels/MegaQC
 .. |Gitter| image:: https://img.shields.io/badge/gitter-%20join%20chat%20%E2%86%92-4fb99a.svg?style=flat-square
    :target: https://gitter.im/ewels/MegaQC

--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,8 @@ to learn how to install, deploy and use MegaQC.
 .. _GitHub repository: https://github.com/ewels/MultiQC
 
 .. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/main/megaqc/static/img/MegaQC_logo.png
-.. |Docker| image:: https://img.shields.io/docker/automated/ewels/megaqc.svg?style=flat-square
-   :target: https://hub.docker.com/r/ewels/megaqc/
-.. |Build Status| image:: https://travis-ci.org/ewels/MegaQC.svg?branch=main
-   :target: https://travis-ci.org/ewels/MegaQC
+.. |Docker| image:: https://img.shields.io/docker/automated/multiqc/megaqc.svg?style=flat-square
+   :target: https://hub.docker.com/r/multiqc/megaqc/
 .. |Gitter| image:: https://img.shields.io/badge/gitter-%20join%20chat%20%E2%86%92-4fb99a.svg?style=flat-square
    :target: https://gitter.im/ewels/MegaQC
 .. |Documentation| image:: https://img.shields.io/badge/Documentation-passing-passing

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ MegaQC is a web application that you can install and run on your own
 network. It collects and visualises data parsed by MultiQC across multiple runs.
 The MegaQC home page looks something like this:
 
-.. figure:: https://raw.githubusercontent.com/ewels/MegaQC/master/docs/source/images/megaqc_homepage.png
+.. figure:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/docs/source/images/megaqc_homepage.png
    :alt: MegaQC homepage
 
    Screenshot of the MegaQC home page.
@@ -37,7 +37,7 @@ to learn how to install, deploy and use MegaQC.
 .. _MultiQC website: http://multiqc.info
 .. _GitHub repository: https://github.com/ewels/MultiQC
 
-.. |MegaQC| image:: https://raw.githubusercontent.com/ewels/MegaQC/master/megaqc/static/img/MegaQC_logo.png
+.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/megaqc/static/img/MegaQC_logo.png
 .. |Docker| image:: https://img.shields.io/docker/automated/ewels/megaqc.svg?style=flat-square
    :target: https://hub.docker.com/r/ewels/megaqc/
 .. |Build Status| image:: https://travis-ci.org/ewels/MegaQC.svg?branch=master

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   megaqc:
-    image: ewels/megaqc
+    image: multiqc/megaqc
     build: ..
     volumes:
       # Share the static files via a volume

--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -27,7 +27,7 @@
 									<li><a href="docs/index.html" title="Read the MegaQC documentation">Docs</a></li>
 									<li><a href="http://multiqc.info/" target="_blank" title="Find out more about MultiQC, which MegaQC relies upon">MultiQC</a></li>
 									<li><a href="https://gitter.im/ewels/MegaQC" target="_blank" title="Get help by chatting with the developers">Gitter</a></li>
-									<li><a href="https://github.com/ewels/MegaQC" target="_blank" title="View the code on GitHub">GitHub</a></li>
+									<li><a href="https://github.com/MultiQC/MegaQC" target="_blank" title="View the code on GitHub">GitHub</a></li>
 								</ul>
 							</nav>
 
@@ -186,7 +186,7 @@
               <ul class="actions">
                 <li><a href="docs/index.html" class="button style2">Read the docs</a></li>
                 <li><a href="#" class="button style1">Try a live demo</a></li>
-                <li><a href="https://github.com/ewels/MegaQC" target="_blank" class="button style2">See the code</a></li>
+                <li><a href="https://github.com/MultiQC/MegaQC" target="_blank" class="button style2">See the code</a></li>
               </ul>
 						</header>
 

--- a/docs/source/_templates/index.html
+++ b/docs/source/_templates/index.html
@@ -26,7 +26,7 @@
 									<li class="current"><a href="index.html">Home</a></li>
 									<li><a href="docs/index.html" title="Read the MegaQC documentation">Docs</a></li>
 									<li><a href="http://multiqc.info/" target="_blank" title="Find out more about MultiQC, which MegaQC relies upon">MultiQC</a></li>
-									<li><a href="https://gitter.im/ewels/MegaQC" target="_blank" title="Get help by chatting with the developers">Gitter</a></li>
+									<li><a href="https://gitter.im/MultiQC/MegaQC" target="_blank" title="Get help by chatting with the developers">Gitter</a></li>
 									<li><a href="https://github.com/MultiQC/MegaQC" target="_blank" title="View the code on GitHub">GitHub</a></li>
 								</ul>
 							</nav>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,7 @@ html_context = {
     "display_github": True,
     # Set the following variables to generate the resulting github URL for each page.
     # Format Template: https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
-    "github_user": "ewels",
+    "github_user": "MultiQC",
     "github_repo": "MegaQC",
     "github_version": "main/docs",
     "conf_py_path": "/source/",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,4 +98,4 @@ def linkcode_resolve(domain, info):
     tag = "master"
     # TODO use this after the first release: tag = 'master' if 'dev' in release else ('v' + release)
 
-    return "https://github.com/ewels/megaqc/blob/%s/%s" % (tag, filename)
+    return "https://github.com/MultiQC/MegaQC/blob/%s/%s" % (tag, filename)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -69,7 +69,7 @@ html_context = {
     # Format Template: https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
     "github_user": "ewels",
     "github_repo": "MegaQC",
-    "github_version": "master/docs",
+    "github_version": "main/docs",
     "conf_py_path": "/source/",
 }
 
@@ -95,7 +95,7 @@ def linkcode_resolve(domain, info):
         filename = "megaqc/%s#L%d-L%d" % find_source()
     except Exception:
         filename = info["module"].replace(".", "/") + ".py"
-    tag = "master"
-    # TODO use this after the first release: tag = 'master' if 'dev' in release else ('v' + release)
+    tag = "main"
+    # TODO use this after the first release: tag = 'main' if 'dev' in release else ('v' + release)
 
     return "https://github.com/MultiQC/MegaQC/blob/%s/%s" % (tag, filename)

--- a/docs/source/docs/dev/backend.rst
+++ b/docs/source/docs/dev/backend.rst
@@ -61,16 +61,16 @@ be done inside `test_api.py`_, which tests all REST API endpoints.
 
 .. _flask: https://www.palletsprojects.com/p/flask/
 .. _SQLAlchemy: https://docs.sqlalchemy.org/
-.. _model/models.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/model/models.py
-.. _user/models.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/user/models.py
-.. _megaqc/api: https://github.com/MultiQC/MegaQC/tree/master/megaqc/api
-.. _megaqc/rest_api: https://github.com/MultiQC/MegaQC/tree/master/megaqc/rest_api
-.. _views.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/rest_api/views.py
+.. _model/models.py: https://github.com/MultiQC/MegaQC/blob/main/megaqc/model/models.py
+.. _user/models.py: https://github.com/MultiQC/MegaQC/blob/main/megaqc/user/models.py
+.. _megaqc/api: https://github.com/MultiQC/MegaQC/tree/main/megaqc/api
+.. _megaqc/rest_api: https://github.com/MultiQC/MegaQC/tree/main/megaqc/rest_api
+.. _views.py: https://github.com/MultiQC/MegaQC/blob/main/megaqc/rest_api/views.py
 .. _flapison: https://github.com/TMiguelT/flapison
-.. _schemas.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/rest_api/schemas.py
-.. _public/views.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/public/views.py
-.. _user/views.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/user/views.py
+.. _schemas.py: https://github.com/MultiQC/MegaQC/tree/main/megaqc/rest_api/schemas.py
+.. _public/views.py: https://github.com/MultiQC/MegaQC/tree/main/megaqc/public/views.py
+.. _user/views.py: https://github.com/MultiQC/MegaQC/tree/main/megaqc/user/views.py
 .. _Jinja2: https://jinja.palletsprojects.com/en/2.11.x/
 .. _frontend: ./frontend.md
-.. _python_tests: https://github.com/MultiQC/MegaQC/tree/master/tests
-.. _test_api.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/api/test_api.py
+.. _python_tests: https://github.com/MultiQC/MegaQC/tree/main/tests
+.. _test_api.py: https://github.com/MultiQC/MegaQC/tree/main/megaqc/api/test_api.py

--- a/docs/source/docs/dev/backend.rst
+++ b/docs/source/docs/dev/backend.rst
@@ -13,7 +13,7 @@ will likely be SQLite.
 
 Database models are located in `model/models.py`_ and `user/models.py`_.
 
-Database schema migrations 
+Database schema migrations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You need to generate a new migration whenever the database schema (ie
@@ -61,16 +61,16 @@ be done inside `test_api.py`_, which tests all REST API endpoints.
 
 .. _flask: https://www.palletsprojects.com/p/flask/
 .. _SQLAlchemy: https://docs.sqlalchemy.org/
-.. _model/models.py: https://github.com/ewels/MegaQC/blob/master/megaqc/model/models.py
-.. _user/models.py: https://github.com/ewels/MegaQC/blob/master/megaqc/user/models.py
-.. _megaqc/api: https://github.com/ewels/MegaQC/tree/master/megaqc/api
-.. _megaqc/rest_api: https://github.com/ewels/MegaQC/tree/master/megaqc/rest_api
-.. _views.py: https://github.com/ewels/MegaQC/blob/master/megaqc/rest_api/views.py
+.. _model/models.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/model/models.py
+.. _user/models.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/user/models.py
+.. _megaqc/api: https://github.com/MultiQC/MegaQC/tree/master/megaqc/api
+.. _megaqc/rest_api: https://github.com/MultiQC/MegaQC/tree/master/megaqc/rest_api
+.. _views.py: https://github.com/MultiQC/MegaQC/blob/master/megaqc/rest_api/views.py
 .. _flapison: https://github.com/TMiguelT/flapison
-.. _schemas.py: https://github.com/ewels/MegaQC/tree/master/megaqc/rest_api/schemas.py
-.. _public/views.py: https://github.com/ewels/MegaQC/tree/master/megaqc/public/views.py
-.. _user/views.py: https://github.com/ewels/MegaQC/tree/master/megaqc/user/views.py
+.. _schemas.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/rest_api/schemas.py
+.. _public/views.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/public/views.py
+.. _user/views.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/user/views.py
 .. _Jinja2: https://jinja.palletsprojects.com/en/2.11.x/
 .. _frontend: ./frontend.md
-.. _python_tests: https://github.com/ewels/MegaQC/tree/master/tests
-.. _test_api.py: https://github.com/ewels/MegaQC/tree/master/megaqc/api/test_api.py
+.. _python_tests: https://github.com/MultiQC/MegaQC/tree/master/tests
+.. _test_api.py: https://github.com/MultiQC/MegaQC/tree/master/megaqc/api/test_api.py

--- a/docs/source/docs/dev/documentation.rst
+++ b/docs/source/docs/dev/documentation.rst
@@ -10,8 +10,8 @@ Building the documentation locally
 The MegaQC documentation requires
 
 1. An installation of MegaQC to fetch the API endpoints and the Click commands.
-2. All dependencies specified in the `docs requirements.txt <https://github.com/ewels/MegaQC/blob/master/docs/requirements.txt>`_.
-   Install them by invoking: ``pip install -r docs/requirements.txt``. 
+2. All dependencies specified in the `docs requirements.txt <https://github.com/MultiQC/MegaQC/blob/master/docs/requirements.txt>`_.
+   Install them by invoking: ``pip install -r docs/requirements.txt``.
 
 After having installed all requirements run ``make api-docs && make html`` in the ``docs`` directory.
 The generated ``html`` files are found in the ``docs/_build/html`` subfolder.
@@ -23,4 +23,4 @@ Publishing the documentation
 On pushes to the ``master`` branch, the documentation is automatically built and pushed
 to the ``gh-pages`` branch. The static html files on this branch are then deployed
 to Github Pages and displayed to the outside world.
-All of this is done with the `Publish Docs Github Actions workflow <https://github.com/ewels/MegaQC/blob/master/.github/workflows/publish_docs.yaml>`.
+All of this is done with the `Publish Docs Github Actions workflow <https://github.com/MultiQC/MegaQC/blob/master/.github/workflows/publish_docs.yaml>`.

--- a/docs/source/docs/dev/documentation.rst
+++ b/docs/source/docs/dev/documentation.rst
@@ -10,7 +10,7 @@ Building the documentation locally
 The MegaQC documentation requires
 
 1. An installation of MegaQC to fetch the API endpoints and the Click commands.
-2. All dependencies specified in the `docs requirements.txt <https://github.com/MultiQC/MegaQC/blob/master/docs/requirements.txt>`_.
+2. All dependencies specified in the `docs requirements.txt <https://github.com/MultiQC/MegaQC/blob/main/docs/requirements.txt>`_.
    Install them by invoking: ``pip install -r docs/requirements.txt``.
 
 After having installed all requirements run ``make api-docs && make html`` in the ``docs`` directory.
@@ -20,7 +20,7 @@ Simply open a generated ``html`` file in your favorite browser to read the docum
 Publishing the documentation
 ---------------------------------
 
-On pushes to the ``master`` branch, the documentation is automatically built and pushed
+On pushes to the ``main`` branch, the documentation is automatically built and pushed
 to the ``gh-pages`` branch. The static html files on this branch are then deployed
 to Github Pages and displayed to the outside world.
-All of this is done with the `Publish Docs Github Actions workflow <https://github.com/MultiQC/MegaQC/blob/master/.github/workflows/publish_docs.yaml>`.
+All of this is done with the `Publish Docs Github Actions workflow <https://github.com/MultiQC/MegaQC/blob/main/.github/workflows/publish_docs.yaml>`.

--- a/docs/source/docs/dev/frontend.rst
+++ b/docs/source/docs/dev/frontend.rst
@@ -22,7 +22,7 @@ Note that all new pages going forward should be written using React, to
 improve the maintainability of the frontend.
 
 .. _React: https://reactjs.org/
-.. _templates: https://github.com/MultiQC/MegaQC/tree/master/megaqc/templates
-.. _static: https://github.com/MultiQC/MegaQC/tree/master/megaqc/static
-.. _react.html: https://github.com/MultiQC/MegaQC/tree/master/megaqc/templates/public/react.html
-.. _src: https://github.com/MultiQC/MegaQC/tree/master/src
+.. _templates: https://github.com/MultiQC/MegaQC/tree/main/megaqc/templates
+.. _static: https://github.com/MultiQC/MegaQC/tree/main/megaqc/static
+.. _react.html: https://github.com/MultiQC/MegaQC/tree/main/megaqc/templates/public/react.html
+.. _src: https://github.com/MultiQC/MegaQC/tree/main/src

--- a/docs/source/docs/dev/frontend.rst
+++ b/docs/source/docs/dev/frontend.rst
@@ -22,7 +22,7 @@ Note that all new pages going forward should be written using React, to
 improve the maintainability of the frontend.
 
 .. _React: https://reactjs.org/
-.. _templates: https://github.com/ewels/MegaQC/tree/master/megaqc/templates
-.. _static: https://github.com/ewels/MegaQC/tree/master/megaqc/static
-.. _react.html: https://github.com/ewels/MegaQC/tree/master/megaqc/templates/public/react.html
-.. _src: https://github.com/ewels/MegaQC/tree/master/src
+.. _templates: https://github.com/MultiQC/MegaQC/tree/master/megaqc/templates
+.. _static: https://github.com/MultiQC/MegaQC/tree/master/megaqc/static
+.. _react.html: https://github.com/MultiQC/MegaQC/tree/master/megaqc/templates/public/react.html
+.. _src: https://github.com/MultiQC/MegaQC/tree/master/src

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -23,4 +23,4 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/megaqc/static/img/MegaQC_logo.png
+.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/main/megaqc/static/img/MegaQC_logo.png

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -23,4 +23,4 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. |MegaQC| image:: https://raw.githubusercontent.com/ewels/MegaQC/master/megaqc/static/img/MegaQC_logo.png
+.. |MegaQC| image:: https://raw.githubusercontent.com/MultiQC/MegaQC/master/megaqc/static/img/MegaQC_logo.png

--- a/docs/source/docs/installation/installation_dev.rst
+++ b/docs/source/docs/installation/installation_dev.rst
@@ -17,7 +17,7 @@ If you’re doing development work, you need access to the source code
 
 .. code:: bash
 
-   git clone https://github.com/ewels/MegaQC
+   git clone https://github.com/MultiQC/MegaQC/
 
 2. Install Dependencies
 ------------------------------------------------

--- a/docs/source/docs/installation/installation_docker.rst
+++ b/docs/source/docs/installation/installation_docker.rst
@@ -14,10 +14,10 @@ The MegaQC Docker container
 Overview
 ~~~~~~~~~~
 
-The MegaQC container is based on the `Node container <https://hub.docker.com/_/node>`_ 
+The MegaQC container is based on the `Node container <https://hub.docker.com/_/node>`_
 to compile all Javascript scripts and the `Gunicorn Flask container <https://hub.docker.com/r/tiangolo/meinheld-gunicorn-flask/dockerfile>`_
 providing Gunicorn, Flask and MegaQC preconfigured for production deployments.
-The `Gunicorn Flask <https://hub.docker.com/r/tiangolo/meinheld-gunicorn-flask/dockerfile>`_ container 
+The `Gunicorn Flask <https://hub.docker.com/r/tiangolo/meinheld-gunicorn-flask/dockerfile>`_ container
 is also the one spinning up the final server.
 
 Pulling the docker image from dockerhub
@@ -53,10 +53,10 @@ You can then run MegaQC as described above:
 Configuration
 ~~~~~~~~~~~~~~~
 
-Besides the sections below it is also recommended to read the 
+Besides the sections below it is also recommended to read the
 `Gunicorn Flask container documentation <https://github.com/tiangolo/meinheld-gunicorn-flask-docker>`_,
 which explains how to customize the ``host`` IP where Gunicorn listens
-to requests, the ``port`` the container should listen on and ``bind``, the actual 
+to requests, the ``port`` the container should listen on and ``bind``, the actual
 host and port passed to gunicorn, let alone custom Gunicorn configuration files.
 
 Environment variables
@@ -199,15 +199,15 @@ Overview
 
 The `docker-compose`_ configuration can be accessed in the `deployment folder`_.
 The docker-compose configuration provides the :ref:`megaqc_docker_container`,
-a `postgres container <https://hub.docker.com/_/postgres>`_ for the SQL database 
+a `postgres container <https://hub.docker.com/_/postgres>`_ for the SQL database
 and a `nginx container <https://hub.docker.com/_/nginx>`_ for the reverse proxy setup.
 
 Usage
 ~~~~~~~~
 
 Inside the `deployment folder`_ the `docker-compose`_ configuration
-together with the associated `.env <https://github.com/ewels/MegaQC/blob/master/deployment/.env>`_ file 
-are found. To spin up all containers simply run from inside the `deployment folder <https://github.com/ewels/MegaQC/blob/master/deployment>`_:
+together with the associated `.env <https://github.com/MultiQC/MegaQC/blob/master/deployment/.env>`_ file
+are found. To spin up all containers simply run from inside the `deployment folder <https://github.com/MultiQC/MegaQC/blob/master/deployment>`_:
 
 .. code:: bash
 
@@ -229,18 +229,18 @@ Environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default environment variables for MegaQC used when starting the :ref:`megaqc_docker_container`
-are defined inside the `.env <https://github.com/ewels/MegaQC/blob/master/deployment/.env>`_ file.
+are defined inside the `.env <https://github.com/MultiQC/MegaQC/blob/master/deployment/.env>`_ file.
 Simply edit the file and the new environment variables will be passed to the :ref:`megaqc_docker_container`.
 
 Further runtime arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Further runtime arguments can be added to a 
+Further runtime arguments can be added to a
 `command section <https://docs.docker.com/compose/compose-file/#command>`_
 inside the `docker-compose`_ configuration file.
 
-.. _deployment_folder: https://github.com/ewels/MegaQC/blob/master/deployment
-.. _docker-compose: https://github.com/ewels/MegaQC/blob/master/deployment/docker-compose.yml
+.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/master/deployment
+.. _docker-compose: https://github.com/MultiQC/MegaQC/blob/master/deployment/docker-compose.yml
 .. _dockerhub: https://hub.docker.com/r/ewels/megaqc/
 
 HTTPS

--- a/docs/source/docs/installation/installation_docker.rst
+++ b/docs/source/docs/installation/installation_docker.rst
@@ -27,7 +27,7 @@ To run MegaQC with docker, simply use the following command:
 
 .. code:: bash
 
-   docker run -p 80:80 ewels/megaqc
+   docker run -p 80:80 multiqc/megaqc
 
 This will pull the latest image from `dockerhub`_ and run MegaQC on port 80.
 
@@ -42,13 +42,13 @@ MegaQC code from GitHub. Simply cd to the MegaQC root directory and run
 
 .. code:: bash
 
-   docker build . -t ewels/megaqc
+   docker build . -t multiqc/megaqc
 
 You can then run MegaQC as described above:
 
 .. code:: bash
 
-   docker run -p 80:80 ewels/megaqc
+   docker run -p 80:80 multiqc/megaqc
 
 Configuration
 ~~~~~~~~~~~~~~~
@@ -83,21 +83,21 @@ Running MegaQC for example with a custom database password works as follows:
 
 .. code-block:: bash
 
-   docker run -e DB_PASS=someotherpassword ewels/megaqc
+   docker run -e DB_PASS=someotherpassword multiqc/megaqc
 
 Furthermore, be aware that the default latest tag will typically be a development version
 and may not be very stable. You can specify a tagged version to run a release instead:
 
 .. code:: bash
 
-   docker run -p 80:80 ewels/megaqc:v0.1
+   docker run -p 80:80 multiqc/megaqc:v0.2.0
 
 Also note that docker will use a local version of the image if it
 exists. To pull the latest version of MegaQC use the following command:
 
 .. code:: bash
 
-   docker pull ewels/megaqc
+   docker pull multiqc/megaqc
 
 Using persistent data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,13 +117,13 @@ To create or re-use a docker volume named ``pg_data``:
 
 .. code:: bash
 
-   docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql ewels/megaqc
+   docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql multiqc/megaqc
 
 The same can be done for a log directory volume called ``pg_logs``
 
 .. code:: bash
 
-   docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql -v pg_logs:/var/log/postgresql ewels/megaqc
+   docker run -p 80:80 -v pg_data:/usr/local/lib/postgresql -v pg_logs:/var/log/postgresql multiqc/megaqc
 
 If you did not specify a volume name, docker will have given it a long
 hex string as a unique name. If you do not use volumes frequently, you
@@ -181,7 +181,7 @@ on ``localhost:5432``, looks as follows:
 
 .. code:: bash
 
-   docker run --network="host" -p 5432 ewels/megaqc
+   docker run --network="host" -p 5432 multiqc/megaqc
 
 Note that by default ``localhost=127.0.0.1``.
 
@@ -241,7 +241,7 @@ inside the `docker-compose`_ configuration file.
 
 .. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/main/deployment
 .. _docker-compose: https://github.com/MultiQC/MegaQC/blob/main/deployment/docker-compose.yml
-.. _dockerhub: https://hub.docker.com/r/ewels/megaqc/
+.. _dockerhub: https://hub.docker.com/r/multiqc/megaqc/
 
 HTTPS
 ~~~~~

--- a/docs/source/docs/installation/installation_docker.rst
+++ b/docs/source/docs/installation/installation_docker.rst
@@ -206,8 +206,8 @@ Usage
 ~~~~~~~~
 
 Inside the `deployment folder`_ the `docker-compose`_ configuration
-together with the associated `.env <https://github.com/MultiQC/MegaQC/blob/master/deployment/.env>`_ file
-are found. To spin up all containers simply run from inside the `deployment folder <https://github.com/MultiQC/MegaQC/blob/master/deployment>`_:
+together with the associated `.env <https://github.com/MultiQC/MegaQC/blob/main/deployment/.env>`_ file
+are found. To spin up all containers simply run from inside the `deployment folder <https://github.com/MultiQC/MegaQC/blob/main/deployment>`_:
 
 .. code:: bash
 
@@ -229,7 +229,7 @@ Environment variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default environment variables for MegaQC used when starting the :ref:`megaqc_docker_container`
-are defined inside the `.env <https://github.com/MultiQC/MegaQC/blob/master/deployment/.env>`_ file.
+are defined inside the `.env <https://github.com/MultiQC/MegaQC/blob/main/deployment/.env>`_ file.
 Simply edit the file and the new environment variables will be passed to the :ref:`megaqc_docker_container`.
 
 Further runtime arguments
@@ -239,8 +239,8 @@ Further runtime arguments can be added to a
 `command section <https://docs.docker.com/compose/compose-file/#command>`_
 inside the `docker-compose`_ configuration file.
 
-.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/master/deployment
-.. _docker-compose: https://github.com/MultiQC/MegaQC/blob/master/deployment/docker-compose.yml
+.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/main/deployment
+.. _docker-compose: https://github.com/MultiQC/MegaQC/blob/main/deployment/docker-compose.yml
 .. _dockerhub: https://hub.docker.com/r/ewels/megaqc/
 
 HTTPS

--- a/docs/source/docs/installation/installation_prod.rst
+++ b/docs/source/docs/installation/installation_prod.rst
@@ -170,4 +170,4 @@ If you run an older OS, ensure that the package is installed.
 .. _Python MySQL connector: https://dev.mysql.com/downloads/connector/python/2.1.html
 .. _PyPI package: https://pypi.python.org/pypi/mysql-connector-python/2.0.4
 .. _create an issue: https://github.com/MultiQC/MegaQC/issues/new
-.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/master/deployment
+.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/main/deployment

--- a/docs/source/docs/installation/installation_prod.rst
+++ b/docs/source/docs/installation/installation_prod.rst
@@ -2,8 +2,8 @@ Production
 =============
 
 This section explains how to set up a production environment without
-the usage of container technologies. If you want to run MegaQC in a 
-containerized environment please refer to :ref:`docker_installation`. 
+the usage of container technologies. If you want to run MegaQC in a
+containerized environment please refer to :ref:`docker_installation`.
 
 1. Install the MegaQC package
 -----------------------------
@@ -169,5 +169,5 @@ If you run an older OS, ensure that the package is installed.
 
 .. _Python MySQL connector: https://dev.mysql.com/downloads/connector/python/2.1.html
 .. _PyPI package: https://pypi.python.org/pypi/mysql-connector-python/2.0.4
-.. _create an issue: https://github.com/ewels/MegaQC/issues/new
-.. _deployment_folder: https://github.com/ewels/MegaQC/blob/master/deployment
+.. _create an issue: https://github.com/MultiQC/MegaQC/issues/new
+.. _deployment_folder: https://github.com/MultiQC/MegaQC/blob/master/deployment

--- a/docs/source/docs/troubleshooting.rst
+++ b/docs/source/docs/troubleshooting.rst
@@ -18,9 +18,9 @@ Usage
 
 -  When creating a violin plot I get an error.
 
-   - This is a known issue: https://github.com/ewels/MegaQC/issues/31
+   - This is a known issue: https://github.com/MultiQC/MegaQC/issues/31
 
 -  TypeError: '<' not supported between instances of 'NoneType' and 'float' when trying to compare data
 
-   - This is a known issue: https://github.com/ewels/MegaQC/issues/156
+   - This is a known issue: https://github.com/MultiQC/MegaQC/issues/156
    - Please ensure that your reports do not have missing fields

--- a/megaqc/templates/footer.html
+++ b/megaqc/templates/footer.html
@@ -6,7 +6,7 @@
     <p>
         <a href="http://multiqc.info/db" target="_blank">MegaQC v{{ version }}</a>
          - Written by Phil Ewels, Denis Moreno, Michael Milton, Tor Solli-Nowlan and Lukas Heumos,
-        available on <a href="https://github.com/ewels/MegaQC" target="_blank">GitHub</a>.
+        available on <a href="https://github.com/MultiQC/MegaQC" target="_blank">GitHub</a>.
     </p>
     <p>
       MegaQC uses

--- a/megaqc/templates/nav.html
+++ b/megaqc/templates/nav.html
@@ -19,7 +19,7 @@
         <a class="nav-link" href="{{ url_for('public.about') }}">About{%- if request.path == "/home" %} <span class="sr-only">(current)</span>{% endif %}</a>
       </li>
       <li class="nav-item {% if request.path == "/about" %}active{% endif %}">
-        <a class="nav-link" href="https://gitter.im/ewels/MegaQC" target="_blank" title="Chat on Gitter">Get Help</a>
+        <a class="nav-link" href="https://gitter.im/MultiQC/MegaQC" target="_blank" title="Chat on Gitter">Get Help</a>
       </li>
     </ul>
 

--- a/megaqc/templates/public/home.html
+++ b/megaqc/templates/public/home.html
@@ -24,7 +24,7 @@
   </div>
   <div class="d-xl-none">
     <p class="lead">MegaQC is a web application that collects results from multiple runs of MultiQC and allows bulk visualisation.</p>
-    <p>See the MegaQC GitHub repository for installation instructions and documentation: <a href="https://github.com/ewels/MegaQC" target="_blank">https://github.com/ewels/MegaQC</a></p>
+    <p>See the MegaQC GitHub repository for installation instructions and documentation: <a href="https://github.com/MultiQC/MegaQC" target="_blank">https://github.com/MultiQC/MegaQC/</a></p>
   </div>
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
         "quality control",
 ]
 homepage = "https://megaqc.info/"
-repository = "https://github.com/ewels/MegaQC/"
+repository = "https://github.com/MultiQC/MegaQC"
 documentation = "https://megaqc.info/docs/index.html"
 classifiers = [
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "quality control",
     ],
     url="https://megaqc.info/",
-    download_url="https://github.com/ewels/MegaQC/releases",
+    download_url="https://github.com/MultiQC/MegaQC/releases",
     license="GPLv3",
     packages=["megaqc"],
     include_package_data=True,


### PR DESCRIPTION
I'm in the process of moving MultiQC and related repos off my personal GitHub account and over to the `MultiQC` GitHub organisation.

I'd like to move MegaQC too, is everyone ok with me moving it to `MultiQC` org?

Only downside I can see is that the name becomes `MultiQC/MegaQC` which is maybe a bit of a typo-prone mess. But hopefully it's clear enough.

I'm also taking this as an opportunity to rename default branches from `master` to `main`.