### PR TITLE
Limit max_instances to 1 for the scheduler to prevent conflicts

### DIFF
--- a/megaqc/settings.py
+++ b/megaqc/settings.py
@@ -33,7 +33,7 @@ class Config(object):
     CACHE_TYPE = "simple"  # Can be "memcached", "redis", etc.
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     JOBS = [
-        {"id": "job1", "func": upload_reports_job, "trigger": "interval", "seconds": 30}
+        {"id": "job1", "func": upload_reports_job, "trigger": "interval", "seconds": 30, "max_instances": 1}
     ]
     SCHEDULER_API_ENABLED = True
     EXTRA_CONFIG = env("MEGAQC_CONFIG", None)


### PR DESCRIPTION
<!-- Many thanks for contributing to MegaQC! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] `docs/changelog.md` is updated

**Description of changes**

Fixes #526 

MegaQC ingests reports via an asynchronous scheduler job. If multiple scheduler jobs run concurrently, they can create conflicts. This change prevents that from happening be setting `APScheduler`'s `max_instances` parameter to `1`.