### PR TITLE
Create separate sample_data_type records for different sections

### DIFF
--- a/megaqc/api/utils.py
+++ b/megaqc/api/utils.py
@@ -155,15 +155,16 @@ def handle_report_data(user, report_data):
 
             # Go through each data key
             for d_key in report_data["report_saved_raw_data"][s_key][s_name]:
+                section_data_key = "{}__{}".format(section, d_key)
                 # Save / load the data type
                 key_type = (
                     db.session.query(SampleDataType)
-                    .filter(SampleDataType.data_id == d_key)
+                    .filter(SampleDataType.data_key == section_data_key)
                     .first()
                 )
                 if not key_type:
                     key_type = SampleDataType(
-                        data_key="{}__{}".format(section, d_key),
+                        data_key=section_data_key,
                         data_section=section,
                         data_id=d_key,
                     )


### PR DESCRIPTION
**PR Checklist**

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] `docs/changelog.md` is updated

**Description of changes**

* Fixes https://github.com/MultiQC/MegaQC/issues/530
  * When handling a report, megaqc checks to see if that `SampleDataType` already exists. However it only checks on the basis of `data_id`, but ignores `data_section`. Therefore if multiple report types (data sections) reuse the same `data_id`, currently this will reuse that `SampleDataType` even if `data_section` is wrong for the incoming report.
* This PR adjusts the logic so that it checks for previous `SampleDataType` entries based on `data_key`, which includes both `data_id` and `data_section`.